### PR TITLE
feat: 포인트 API 구현 #29

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/member/Member.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/member/Member.java
@@ -22,7 +22,7 @@ import uk.jinhy.survey_mate_api.data_comment.DataComment;
 import uk.jinhy.survey_mate_api.deviceToken.DeviceToken;
 import uk.jinhy.survey_mate_api.notification.Notification;
 import uk.jinhy.survey_mate_api.data.domain.entity.PurchaseHistory;
-import uk.jinhy.survey_mate_api.statement.Statement;
+import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
 import uk.jinhy.survey_mate_api.survey.domain.entity.Survey;
 import uk.jinhy.survey_mate_api.survey.domain.entity.SurveyComment;
 

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/application/dto/StatementServiceDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/application/dto/StatementServiceDTO.java
@@ -1,0 +1,13 @@
+package uk.jinhy.survey_mate_api.statement.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class StatementServiceDTO {
+    @Builder
+    @Getter
+    public static class CreateStatementDTO {
+        private Long amount;
+        private String description;
+    }
+}

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
@@ -1,0 +1,42 @@
+package uk.jinhy.survey_mate_api.statement.application.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.jinhy.survey_mate_api.member.Member;
+import uk.jinhy.survey_mate_api.statement.application.dto.StatementServiceDTO;
+import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
+import uk.jinhy.survey_mate_api.statement.domain.repository.StatementRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class StatementService {
+    private StatementRepository statementRepository;
+
+    public Statement createStatement(Member member, StatementServiceDTO.CreateStatementDTO dto) {
+        Statement statement = Statement.builder()
+                .amount(dto.getAmount())
+                .description(dto.getDescription())
+                .build();
+        statementRepository.save(statement);
+        return statement;
+    }
+
+    public Statement getStatement(Long statementId) {
+        return statementRepository.findByStatementId(statementId).get();
+    }
+
+    public Long getTotalAmountOfMember(Member member) {
+        return statementRepository.findTotalAmountByMember(member);
+    }
+
+    public List<Statement> getStatementAsBuyer(Member buyer) {
+        return statementRepository.findByBuyer(buyer);
+    }
+
+    public List<Statement> getStatementAsSeller(Member seller) {
+        return statementRepository.findBySeller(seller);
+    }
+}

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
@@ -1,4 +1,4 @@
-package uk.jinhy.survey_mate_api.statement;
+package uk.jinhy.survey_mate_api.statement.domain.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/domain/repository/StatementRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/domain/repository/StatementRepository.java
@@ -1,0 +1,21 @@
+package uk.jinhy.survey_mate_api.statement.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import uk.jinhy.survey_mate_api.member.Member;
+import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StatementRepository extends JpaRepository<Statement, Long> {
+    Optional<Statement> findByStatementId(Long id);
+    List<Statement> findByMember(Member member);
+
+    @Query("select sum(statement.amount) from Statement statement where statement.member = :member")
+    Long findTotalAmountByMember(Member member);
+    @Query("select statement from Statement statement where statement.member = :buyer and statement.amount  < 0")
+    List<Statement> findByBuyer(Member buyer);
+    @Query("select statement from Statement statement where statement.member = :seller and statement.amount  > 0")
+    List<Statement> findBySeller(Member seller);
+}

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
@@ -1,0 +1,13 @@
+package uk.jinhy.survey_mate_api.statement.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import uk.jinhy.survey_mate_api.statement.application.service.StatementService;
+
+@RequiredArgsConstructor
+@RequestMapping("/statement")
+@Controller
+public class StatementController {
+    private final StatementService statementService;
+}

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
@@ -1,0 +1,4 @@
+package uk.jinhy.survey_mate_api.statement.presentation.converter;
+
+public class StatementConverter {
+}

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/dto/StatementControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/dto/StatementControllerDTO.java
@@ -1,0 +1,4 @@
+package uk.jinhy.survey_mate_api.statement.presentation.dto;
+
+public class StatementControllerDTO {
+}


### PR DESCRIPTION
다음과 같은 기능을 구현했습니다.
- 포인트 총합 조회
- 포인트 지출 내역 조회
- 포인트 수령 내역 조회
- 포인트 내역 추가

포인트 사용 및 적립의 경우, 포인트 내역 추가를 통해 구현이 될 거 같아서 별도로 만들지 않았습니다
- 포인트 사용 -> amount를 음수값으로 해서 포인트 내역에 추가
- 포인트 적립 -> amount를 양수값으로 해서 포인트 내역에 추가
- 포인트 조회 -> 특정 member의 포인트 전체 내역의 amount 값을 합산

피드백해주시면 감사하겠습니다.!