### PR TITLE
chore: 실제 메일 전송 대신 임시 responseDTO로 인증코드 전달 #63

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/auth/application/service/AuthService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/application/service/AuthService.java
@@ -111,7 +111,7 @@ public class AuthService {
 
     }
 
-    public void sendMailCode(AuthControllerDTO.CertificateCodeRequestDTO requestDTO){
+    public String sendMailCode(AuthControllerDTO.CertificateCodeRequestDTO requestDTO){
         String memberId = requestDTO.getReceiver();
         if (memberRepository.existsByMemberId(memberId)) {
             throw new GeneralException(Status.DUPLICATE_MAIL);
@@ -127,7 +127,8 @@ public class AuthService {
                 .createdAt(LocalDateTime.now())
                 .build();
         mailCodeRepository.save(mailCode);
-        mailService.sendEmail(requestDTO, mailValidationCode);
+        return mailValidationCode;
+        //mailService.sendEmail(requestDTO, mailValidationCode);
     }
 
     public AuthControllerDTO.EmailCodeResponseDTO checkEmailCode(AuthControllerDTO.MailCodeRequestDTO mailCodeDto){
@@ -157,7 +158,7 @@ public class AuthService {
                 .build();
     }
 
-    public void sendPasswordResetCode(AuthControllerDTO.CertificateCodeRequestDTO requestDTO){
+    public String sendPasswordResetCode(AuthControllerDTO.CertificateCodeRequestDTO requestDTO){
         String memberId = requestDTO.getReceiver();
         Member member = getMemberById(memberId);
 
@@ -172,7 +173,8 @@ public class AuthService {
                 .build();
 
         passwordResetCodeRepository.save(passwordResetCode);
-        mailService.sendEmail(requestDTO, accountValidationCode);
+        return accountValidationCode;
+        //mailService.sendEmail(requestDTO, accountValidationCode);
     }
 
     public AuthControllerDTO.PasswordResetCodeResponseDTO checkPasswordResetCode(AuthControllerDTO.PasswordResetCodeRequestDTO resetDTO){

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/AuthController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package uk.jinhy.survey_mate_api.auth.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.apache.bcel.classfile.Code;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.jinhy.survey_mate_api.auth.application.service.AuthService;
 import uk.jinhy.survey_mate_api.auth.domain.entity.Member;
 import uk.jinhy.survey_mate_api.auth.presentation.dto.AuthControllerDTO;
+import uk.jinhy.survey_mate_api.auth.presentation.dto.CodeResponseDTO;
 import uk.jinhy.survey_mate_api.common.response.ApiResponse;
 import uk.jinhy.survey_mate_api.common.response.Status;
 
@@ -46,9 +48,12 @@ public class AuthController {
     public ApiResponse<?> sendEmailCode(
             @RequestBody @Valid AuthControllerDTO.CertificateCodeRequestDTO requestDTO
             ){
-        authService.sendMailCode(requestDTO);
+        String mailValidationCode = authService.sendMailCode(requestDTO);
+        CodeResponseDTO responseDTO = CodeResponseDTO.builder()
+                .code(mailValidationCode)
+                .build();
         return ApiResponse.onSuccess(Status.OK.getCode(),
-                Status.OK.getMessage(), null);
+                Status.OK.getMessage(), responseDTO);
     }
 
     @PostMapping("/email/certification")
@@ -66,9 +71,12 @@ public class AuthController {
     public ApiResponse<?> sendPasswordResetCode(
             @RequestBody @Valid AuthControllerDTO.CertificateCodeRequestDTO requestDTO
     ){
-        authService.sendPasswordResetCode(requestDTO);
+        String accountValidationCode = authService.sendPasswordResetCode(requestDTO);
+        CodeResponseDTO responseDTO = CodeResponseDTO.builder()
+                .code(accountValidationCode)
+                .build();
         return ApiResponse.onSuccess(Status.OK.getCode(),
-                Status.OK.getMessage(), null);
+                Status.OK.getMessage(), responseDTO);
     }
 
     @PostMapping("/password/certification")

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/dto/CodeResponseDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/dto/CodeResponseDTO.java
@@ -1,0 +1,12 @@
+package uk.jinhy.survey_mate_api.auth.presentation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CodeResponseDTO {
+
+    private String code;
+
+}


### PR DESCRIPTION
실제 이메일 전송하는 코드는 나중에 최종 배포 때를 위해 주석 처리한 점 양해 부탁드립니다..