### PR TITLE
fix: 설문장터 API 수정 #103

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/common/aws/S3Service.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/common/aws/S3Service.java
@@ -31,8 +31,8 @@ public class S3Service {
         return amazonS3.getUrl(config.getBucket(), keyName).toString();
     }
 
-    public String generateDataFileKeyName(String uuid) {
-        return config.getDataFilePath() + '/' + uuid;
+    public String generateDataFileKeyName(String uuid, String extension) {
+        return config.getDataFilePath() + '/' + uuid + '.' + extension;
     }
 }
 

--- a/src/main/java/uk/jinhy/survey_mate_api/common/response/Status.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/common/response/Status.java
@@ -53,6 +53,8 @@ public enum Status {
 
     STATEMENT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "STATEMENT400", "포인트가 부족합니다."),
 
+    DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "DATA404", "판매 중인 설문조사를 찾을 수 없습니다."),
+
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/dto/DataServiceDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/dto/DataServiceDTO.java
@@ -23,5 +23,7 @@ public class DataServiceDTO {
         private Long dataId;
         private String title;
         private String description;
+        private Long price;
+        private MultipartFile file;
     }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import uk.jinhy.survey_mate_api.auth.domain.entity.Member;
 import uk.jinhy.survey_mate_api.common.aws.S3Service;
@@ -29,8 +30,9 @@ public class DataService {
             throw new GeneralException(Status.BAD_REQUEST);
         }
 
+        String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
         String fileURL = s3Service.uploadFile(
-            s3Service.generateDataFileKeyName(Util.generateRandomString(10)), file);
+            s3Service.generateDataFileKeyName(Util.generateRandomString(10)) + extension, file);
 
         Data data = Data.builder()
             .seller(seller)

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -39,6 +39,7 @@ public class DataService {
             .description(dto.getDescription())
             .price(dto.getPrice())
             .seller(seller)
+            .isDeleted(false)
             .build();
 
         dataRepository.save(data);
@@ -69,15 +70,19 @@ public class DataService {
 
     @Transactional
     public void deleteData(Member seller, Long dataId) {
-        Data data = dataRepository.findByDataId(dataId).get();
+        Data data = dataRepository.findByDataId(dataId)
+                .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
+
         if (data.getSeller().equals(seller)) {
-            dataRepository.deleteById(dataId);
+            data.updateIsDeleted(false);
+            dataRepository.save(data);
         }
     }
 
     @Transactional
     public Long buyData(Member buyer, Long dataId) {
-        Data data = dataRepository.findByDataId(dataId).get();
+        Data data = dataRepository.findByDataId(dataId)
+                .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
 
         PurchaseHistory purchaseHistory = PurchaseHistory.builder()
             .data(data)

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -65,6 +65,19 @@ public class DataService {
             data.updateDescription(newDescription);
         }
 
+        Long newPrice = dto.getPrice();
+        if (newPrice != null) {
+            data.updatePrice(newPrice);
+        }
+
+        MultipartFile newFile = dto.getFile();
+        if (newFile != null) {
+            String fileURL = s3Service.uploadFile(
+                    s3Service.generateDataFileKeyName(Util.generateRandomString(10)), newFile);
+
+            data.updateFileUrl(fileURL);
+        }
+
         dataRepository.save(data);
     }
 

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -79,8 +79,6 @@ public class DataService {
 
             data.updateFileUrl(fileURL);
         }
-
-        dataRepository.save(data);
     }
 
     @Transactional
@@ -89,8 +87,7 @@ public class DataService {
                 .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
 
         if (data.getSeller().equals(seller)) {
-            data.updateIsDeleted(false);
-            dataRepository.save(data);
+            data.updateIsDeleted(true);
         }
     }
 

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -90,7 +90,8 @@ public class DataService {
     }
 
     public Data getData(Long dataId) {
-        return dataRepository.findByDataId(dataId).get();
+        return dataRepository.findByDataId(dataId)
+                .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
     }
 
     public List<Data> getDataListAsBuyer(Member buyer) {

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -32,7 +32,7 @@ public class DataService {
 
         String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
         String fileURL = s3Service.uploadFile(
-            s3Service.generateDataFileKeyName(Util.generateRandomString(10)) + extension, file);
+            s3Service.generateDataFileKeyName(Util.generateRandomString(10), extension), file);
 
         Data data = Data.builder()
             .seller(seller)
@@ -74,8 +74,9 @@ public class DataService {
 
         MultipartFile newFile = dto.getFile();
         if (newFile != null) {
+            String extension = StringUtils.getFilenameExtension(newFile.getOriginalFilename());
             String fileURL = s3Service.uploadFile(
-                    s3Service.generateDataFileKeyName(Util.generateRandomString(10)), newFile);
+                    s3Service.generateDataFileKeyName(Util.generateRandomString(10), extension), newFile);
 
             data.updateFileUrl(fileURL);
         }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
@@ -81,6 +81,8 @@ public class Data {
         title = newDescription;
     }
 
+    public void updatePrice(Long newPrice) { price = newPrice; }
+
     public void updateIsDeleted(Boolean newIsDeleted) { isDeleted = newIsDeleted;}
 
     public void updateFileUrl(String newFileUrl) {

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
@@ -52,6 +52,9 @@ public class Data {
     @NotNull
     private Long price;
 
+    @NotNull
+    private Boolean isDeleted;
+
     @Builder.Default
     @OneToMany(mappedBy = "data", cascade = CascadeType.ALL)
     private List<PurchaseHistory> purchaseHistoryList = new ArrayList<>();
@@ -77,6 +80,8 @@ public class Data {
     public void updateDescription(String newDescription) {
         title = newDescription;
     }
+
+    public void updateIsDeleted(Boolean newIsDeleted) { isDeleted = newIsDeleted;}
 
     public void updateFileUrl(String newFileUrl) {
         title = newFileUrl;

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
@@ -78,7 +78,7 @@ public class Data {
     }
 
     public void updateDescription(String newDescription) {
-        title = newDescription;
+        description = newDescription;
     }
 
     public void updatePrice(Long newPrice) { price = newPrice; }
@@ -86,6 +86,6 @@ public class Data {
     public void updateIsDeleted(Boolean newIsDeleted) { isDeleted = newIsDeleted;}
 
     public void updateFileUrl(String newFileUrl) {
-        title = newFileUrl;
+        fileUrl = newFileUrl;
     }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/entity/Data.java
@@ -65,6 +65,11 @@ public class Data {
         seller.addData(this);
     }
 
+    public boolean isPurchased(Member member) {
+        return purchaseHistoryList.stream()
+                .anyMatch(a -> a.getBuyer().equals(member));
+    }
+
     public void updateTitle(String newTitle) {
         title = newTitle;
     }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
@@ -11,6 +11,8 @@ public interface DataRepository extends JpaRepository<Data, Long> {
 
     Optional<Data> findByDataId(Long id);
 
+    @Query("select data from Data data "
+            + "where data.seller = :member and data.isDeleted = false")
     List<Data> findBySeller(Member member);
 
     @Query("select data from Data data "
@@ -18,6 +20,8 @@ public interface DataRepository extends JpaRepository<Data, Long> {
         + "where purchase_history.buyer = :member")
     List<Data> findByBuyer(Member member);
 
-    @Query("select data from Data data order by data.createdAt limit 15")
+    @Query("select data from Data data "
+            + "where data.isDeleted = false"
+            + " order by data.createdAt limit 15 ")
     List<Data> findRecentData();
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
@@ -54,7 +54,7 @@ public class DataController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
     }
 
-    @PatchMapping(value = "/{dataId}")
+    @PatchMapping(value = "/{dataId}", consumes = { "multipart/form-data" })
     @Operation(summary = "설문장터 수정")
     public ApiResponse<?> editData(
         @ModelAttribute DataControllerDTO.EditDataRequestDTO requestDTO,

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
@@ -47,7 +47,9 @@ public class DataController {
             @PathVariable("dataId") Long dataId
     ) {
         Data data = dataService.getData(dataId);
-        DataControllerDTO.DataDetailDTO responseDTO = converter.toControllerDataDetailDto(data);
+        Member member = authService.getCurrentMember();
+
+        DataControllerDTO.DataDetailDTO responseDTO = converter.toControllerDataDetailDto(data, data.isPurchased(member));
 
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
     }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
@@ -30,6 +30,8 @@ public class DataConverter {
             .dataId(dataId)
             .title(controllerDTO.getTitle())
             .description(controllerDTO.getDescription())
+            .price(controllerDTO.getAmount())
+            .file(controllerDTO.getFile())
             .build();
     }
 

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
@@ -47,7 +47,7 @@ public class DataConverter {
                 .build();
     }
 
-    public DataControllerDTO.DataDetailDTO toControllerDataDetailDto(Data data) {
+    public DataControllerDTO.DataDetailDTO toControllerDataDetailDto(Data data, Boolean isPurchased) {
         return DataControllerDTO.DataDetailDTO.builder()
                 .seller(data.getSeller().getNickname())
                 .createdAt(data.getCreatedAt())
@@ -55,6 +55,7 @@ public class DataConverter {
                 .description(data.getDescription())
                 .price(data.getPrice())
                 .fileUrl(data.getFileUrl())
+                .isPurchased(isPurchased)
                 .build();
     }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/converter/DataConverter.java
@@ -37,6 +37,7 @@ public class DataConverter {
 
     public DataControllerDTO.DataDTO toControllerDataDto(Data data) {
         return DataControllerDTO.DataDTO.builder()
+                .dataId(data.getDataId())
                 .title(data.getTitle())
                 .description(data.getDescription())
                 .createdAt(data.getCreatedAt())

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
@@ -48,6 +48,7 @@ public class DataControllerDTO {
         private String description;
         private Long price;
         private String fileUrl;
+        private Boolean isPurchased;
     }
 
     @Builder

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
@@ -24,9 +24,10 @@ public class DataControllerDTO {
     @Getter
     @AllArgsConstructor
     public static class EditDataRequestDTO {
-
         private String title;
         private String description;
+        private Long amount;
+        private MultipartFile file;
     }
 
     @Builder

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/dto/DataControllerDTO.java
@@ -34,6 +34,7 @@ public class DataControllerDTO {
     @Getter
     @AllArgsConstructor
     public static class DataDTO {
+        private Long dataId;
         private String title;
         private String description;
         private LocalDateTime createdAt;


### PR DESCRIPTION
다음과 같은 기능을 구현했습니다.
- 없는 설문장터 조회 시 400번대 에러 반환
<img width="1233" alt="스크린샷 2024-02-08 오전 3 35 45" src="https://github.com/survey-mate/backend/assets/73176655/22ddda42-d57c-4c61-a6f9-10233801ada8">
- S3에 파일 저장할 때 확장자 포함하도록 + 설문장터 구매 여부 확인 로직(ResponseDTO에 isPurchased 전달)
<img width="1252" alt="스크린샷 2024-02-08 오전 3 43 57" src="https://github.com/survey-mate/backend/assets/73176655/3cb365e8-150c-48d0-baad-3288413d36ea">
- 설문장터 수정 시 파일 + 판매 금액 수정 가능하도록
<img width="824" alt="스크린샷 2024-02-08 오전 4 00 37" src="https://github.com/survey-mate/backend/assets/73176655/6a078d06-663f-4e56-a21d-3f5e1560337e">
<img width="1353" alt="스크린샷 2024-02-08 오전 4 01 22" src="https://github.com/survey-mate/backend/assets/73176655/d6fb5add-9683-49f1-b020-e54c02ab0d7f">
- 설문장터 게시글이 삭제되어도 구매한 설문 데이터는 구매자가 열람 가능하도록




