### PR TITLE
fix: Statement API 로직 수정 #118

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataServiceFacade.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataServiceFacade.java
@@ -17,14 +17,24 @@ public class DataServiceFacade {
 
     @Transactional
     public void buyData(Member buyer, Long dataId) {
+        Member seller = dataService.getData(dataId).getSeller();
         Long price = dataService.buyData(buyer, dataId);
 
         StatementServiceDTO.PayPointDTO payPointDTO = StatementServiceDTO
             .PayPointDTO
             .builder()
-            .description("설문조사 구매")
+            .description("설문 응답 데이터 구매")
             .amount(price)
             .build();
+
+        StatementServiceDTO.EarnPointDTO earnPointDTO = StatementServiceDTO
+                .EarnPointDTO
+                .builder()
+                .description("설문 응답 데이터 판매")
+                .amount(price)
+                .build();
+
         statementService.payPoint(buyer, payPointDTO);
+        statementService.earnPoint(seller, earnPointDTO);
     }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
@@ -76,7 +76,7 @@ public class DataController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), null);
     }
 
-    @GetMapping(value = "/buy/{dataId}")
+    @PostMapping(value = "/buy/{dataId}")
     @Operation(summary = "설문장터 구매")
     public ApiResponse<Object> buyData(
         @PathVariable("dataId") Long dataId

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
@@ -21,6 +21,7 @@ public class StatementService {
             .member(member)
             .amount(-1L * dto.getAmount())
             .description(dto.getDescription())
+            .balance(getTotalAmount(member) + -1L * dto.getAmount())
             .build();
 
         if (getTotalAmount(member) + statement.getAmount() < 0) {
@@ -35,6 +36,7 @@ public class StatementService {
             .member(member)
             .amount(dto.getAmount())
             .description(dto.getDescription())
+            .balance(getTotalAmount(member) + dto.getAmount())
             .build();
 
         statementRepository.save(statement);
@@ -52,11 +54,11 @@ public class StatementService {
         return statementRepository.findTotalAmountByMember(member);
     }
 
-    public List<Statement> getStatementAsBuyer(Member buyer) {
+    public List<Statement> getStatementListAsBuyer(Member buyer) {
         return statementRepository.findByBuyer(buyer);
     }
 
-    public List<Statement> getStatementAsSeller(Member seller) {
+    public List<Statement> getStatementListAsSeller(Member seller) {
         return statementRepository.findBySeller(seller);
     }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
@@ -1,13 +1,7 @@
 package uk.jinhy.survey_mate_api.statement.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import uk.jinhy.survey_mate_api.auth.domain.entity.Member;
 
 import java.time.LocalDateTime;
@@ -24,6 +19,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Statement {
 
     @Id

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/domain/entity/Statement.java
@@ -14,7 +14,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import uk.jinhy.survey_mate_api.auth.domain.entity.Member;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -27,7 +30,6 @@ public class Statement {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long statementId;
 
-    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @NotNull
@@ -36,8 +38,14 @@ public class Statement {
     @NotNull
     private Long amount;
 
+    @CreatedDate
+    private LocalDateTime createdAt;
+
     @NotNull
     private String description;
+
+    @NotNull
+    private Long balance;
 
     public void confirmMember(Member member) {
         this.member = member;

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
@@ -29,10 +29,6 @@ public class StatementController {
     public ApiResponse<StatementControllerDTO.StatementListDTO> getStatementList() {
         Member member = authService.getCurrentMember();
 
-        if(member == null) {
-            throw new GeneralException(Status.UNAUTHORIZED);
-        }
-
         List<Statement> statementList = statementService.getStatementList(member);
         StatementControllerDTO.StatementListDTO responseDTO =
             new StatementControllerDTO.StatementListDTO(statementList);

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/StatementController.java
@@ -14,6 +14,7 @@ import uk.jinhy.survey_mate_api.common.response.Status;
 import uk.jinhy.survey_mate_api.common.response.exception.GeneralException;
 import uk.jinhy.survey_mate_api.statement.application.service.StatementService;
 import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
+import uk.jinhy.survey_mate_api.statement.presentation.converter.StatementConverter;
 import uk.jinhy.survey_mate_api.statement.presentation.dto.StatementControllerDTO;
 
 @RequiredArgsConstructor
@@ -24,14 +25,37 @@ public class StatementController {
     private final StatementService statementService;
     private final AuthService authService;
 
+    private final StatementConverter converter;
+
     @GetMapping(value = "/list")
-    @Operation(summary = "전체 사용내역 조회")
+    @Operation(summary = "포인트 전체 내역 조회")
     public ApiResponse<StatementControllerDTO.StatementListDTO> getStatementList() {
         Member member = authService.getCurrentMember();
 
         List<Statement> statementList = statementService.getStatementList(member);
-        StatementControllerDTO.StatementListDTO responseDTO =
-            new StatementControllerDTO.StatementListDTO(statementList);
+        StatementControllerDTO.StatementListDTO responseDTO = converter.toControllerStatementListDto(statementList);
+
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
+    }
+
+    @GetMapping(value = "/list/buyer")
+    @Operation(summary = "포인트 사용 내역 조회")
+    public ApiResponse<StatementControllerDTO.StatementListDTO> getStatementListAsBuyer() {
+        Member member = authService.getCurrentMember();
+
+        List<Statement> statementList = statementService.getStatementListAsBuyer(member);
+        StatementControllerDTO.StatementListDTO responseDTO = converter.toControllerStatementListDto(statementList);
+
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
+    }
+
+    @GetMapping(value = "/list/seller")
+    @Operation(summary = "포인트 수령 내역 조회")
+    public ApiResponse<StatementControllerDTO.StatementListDTO> getStatementListAsSeller() {
+        Member member = authService.getCurrentMember();
+
+        List<Statement> statementList = statementService.getStatementListAsSeller(member);
+        StatementControllerDTO.StatementListDTO responseDTO = converter.toControllerStatementListDto(statementList);
 
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
     }

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
@@ -1,5 +1,25 @@
 package uk.jinhy.survey_mate_api.statement.presentation.converter;
 
-public class StatementConverter {
+import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
+import uk.jinhy.survey_mate_api.statement.presentation.StatementController;
+import uk.jinhy.survey_mate_api.statement.presentation.dto.StatementControllerDTO;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StatementConverter {
+    public StatementControllerDTO.StatementDTO toControllerStatementDto(Statement statement) {
+        return StatementControllerDTO.StatementDTO.builder()
+                .createdAt(statement.getCreatedAt())
+                .amount(statement.getAmount())
+                .balance(statement.getBalance())
+                .description(statement.getDescription())
+                .build();
+    }
+
+    public StatementControllerDTO.StatementListDTO toControllerStatementListDto(List<Statement> statements) {
+        return StatementControllerDTO.StatementListDTO.builder()
+                .statements(statements.stream().map(statement -> toControllerStatementDto(statement)).collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/converter/StatementConverter.java
@@ -1,5 +1,6 @@
 package uk.jinhy.survey_mate_api.statement.presentation.converter;
 
+import org.springframework.stereotype.Component;
 import uk.jinhy.survey_mate_api.statement.domain.entity.Statement;
 import uk.jinhy.survey_mate_api.statement.presentation.StatementController;
 import uk.jinhy.survey_mate_api.statement.presentation.dto.StatementControllerDTO;
@@ -7,6 +8,7 @@ import uk.jinhy.survey_mate_api.statement.presentation.dto.StatementControllerDT
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Component
 public class StatementConverter {
     public StatementControllerDTO.StatementDTO toControllerStatementDto(Statement statement) {
         return StatementControllerDTO.StatementDTO.builder()

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/dto/StatementControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/presentation/dto/StatementControllerDTO.java
@@ -1,5 +1,6 @@
 package uk.jinhy.survey_mate_api.statement.presentation.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,9 +13,20 @@ public class StatementControllerDTO {
     @Builder
     @Getter
     @AllArgsConstructor
+    public static class StatementDTO {
+
+        private LocalDateTime createdAt;
+        private Long amount;
+        private Long balance;
+        private String description;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
     public static class StatementListDTO {
 
-        private List<Statement> statements;
+        private List<StatementDTO> statements;
     }
 
     @Builder


### PR DESCRIPTION
다음과 같은 부분을 구현했습니다.
- Statement 엔티티 및 Response DTO 수정 
피그마를 확인해보니 잔액과 createdAt 필드가 필요해보여서 엔티티에 추가하고 DTO를 수정했습니다
<img width="516" alt="스크린샷 2024-02-14 오전 11 54 38" src="https://github.com/survey-mate/backend/assets/73176655/3ceb9a47-b671-43ae-bd27-ec36b8505b81">
<img width="1197" alt="스크린샷 2024-02-14 오후 12 01 02" src="https://github.com/survey-mate/backend/assets/73176655/b96af079-7507-426d-9f3c-0a735361c9ed">
- 포인트 수령 Statement와 포인트 사용 Statement만 따로 가져올 수 있는 API를 추가했습니다.
<img width="1146" alt="스크린샷 2024-02-14 오후 12 01 28" src="https://github.com/survey-mate/backend/assets/73176655/43b11312-4d0c-4fd3-8484-7c4ec429d30a">
<img width="1170" alt="스크린샷 2024-02-14 오후 12 01 43" src="https://github.com/survey-mate/backend/assets/73176655/ae750251-c5b0-460c-8d3f-a68404c10b94">
