### PR TITLE
feat: 닉네임 수정 api 추가 #121

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/auth/application/dto/AuthServiceDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/application/dto/AuthServiceDTO.java
@@ -97,4 +97,12 @@ public class AuthServiceDTO {
 
     }
 
+    @Getter
+    @Builder
+    public static class NicknameUpdateDTO {
+
+        private String newNickname;
+
+    }
+
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/application/service/AuthService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/application/service/AuthService.java
@@ -263,6 +263,18 @@ public class AuthService {
         memberRepository.save(member);
     }
 
+    public void updateNickname(AuthServiceDTO.NicknameUpdateDTO dto) {
+        Member member = getCurrentMember();
+        String newNickname = dto.getNewNickname();
+
+        if (checkNickname(newNickname)) {
+            throw new GeneralException(Status.NICKNAME_ALREADY_EXIST);
+        }
+
+        member.changeNickname(newNickname);
+        memberRepository.save(member);
+    }
+
     public void deleteAccount(AuthServiceDTO.DeleteAccountDTO dto) {
         Member member = getCurrentMember();
 

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/domain/entity/Member.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/domain/entity/Member.java
@@ -96,6 +96,10 @@ public class Member {
         password = newPassword;
     }
 
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
     public void setIsStudent(boolean isStudent) {
         this.isStudent = isStudent;
     }

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/AuthController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/AuthController.java
@@ -139,6 +139,17 @@ public class AuthController {
             Status.OK.getMessage(), responseDto);
     }
 
+    @PatchMapping("/nickname")
+    @Operation(summary = "닉네임 변경")
+    public ApiResponse<?> updateNickname(
+            @RequestBody AuthControllerDTO.NicknameUpdateRequestDTO requestDTO
+    ) {
+        AuthServiceDTO.NicknameUpdateDTO nicknameUpdateDTO = authConverter.toServiceNicknameUpdateDTO(requestDTO);
+        authService.updateNickname(nicknameUpdateDTO);
+        return ApiResponse.onSuccess(Status.OK.getCode(),
+                Status.OK.getMessage(), null);
+    }
+
     @GetMapping("/nickname/{nickname}")
     @Operation(summary = "닉네임 중복 확인")
     public ApiResponse<?> checkNickname(

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/converter/AuthConverter.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/converter/AuthConverter.java
@@ -82,4 +82,12 @@ public class AuthConverter {
             .build();
     }
 
+    public AuthServiceDTO.NicknameUpdateDTO toServiceNicknameUpdateDTO(
+            AuthControllerDTO.NicknameUpdateRequestDTO dto
+    ) {
+        return AuthServiceDTO.NicknameUpdateDTO.builder()
+                .newNickname(dto.getNewNickname())
+                .build();
+    }
+
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/dto/AuthControllerDTO.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/auth/presentation/dto/AuthControllerDTO.java
@@ -132,6 +132,19 @@ public class AuthControllerDTO {
 
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NicknameUpdateRequestDTO {
+
+        @NotNull
+        @Schema(description = "새로운 닉네임", example = "로그로그로그")
+        private String newNickname;
+
+    }
+
+
     @NoArgsConstructor
     @Getter
     public static class DeleteAccountRequestDTO {


### PR DESCRIPTION
원래 회원가입 시 닉네임 로그인 상황
![image](https://github.com/survey-mate/backend/assets/96719969/ed29ca8a-5c2e-4b1b-8782-db951f4cacc8)
로그로그로그로 닉네임 수정.
![image](https://github.com/survey-mate/backend/assets/96719969/76a0c004-ddef-4a6f-a09e-6550211c93e5)
다시 로그로그로그로 할 경우 409 에러 
![image](https://github.com/survey-mate/backend/assets/96719969/197b9a5f-2ac6-4338-bf65-0d05a4a84f7a)
