### PR TITLE
fix: Data Statement 최신 목록 조회 쿼리 수정 #132

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -115,7 +115,7 @@ public class DataService {
                 .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
     }
 
-    public List<Data> getDataList() { return dataRepository.findAll(Sort.by(Sort.Direction.DESC, "created_at")); }
+    public List<Data> getDataList() { return dataRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")); }
 
     public List<Data> getDataListAsBuyer(Member buyer) {
         return dataRepository.findByBuyer(buyer);

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -114,7 +115,7 @@ public class DataService {
                 .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
     }
 
-    public List<Data> getDataList () { return dataRepository.findAll(); }
+    public List<Data> getDataList() { return dataRepository.findAll(Sort.by(Sort.Direction.DESC, "created_at")); }
 
     public List<Data> getDataListAsBuyer(Member buyer) {
         return dataRepository.findByBuyer(buyer);

--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -3,6 +3,8 @@ package uk.jinhy.survey_mate_api.data.application.service;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -111,6 +113,8 @@ public class DataService {
         return dataRepository.findByDataId(dataId)
                 .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
     }
+
+    public List<Data> getDataList () { return dataRepository.findAll(); }
 
     public List<Data> getDataListAsBuyer(Member buyer) {
         return dataRepository.findByBuyer(buyer);

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
@@ -15,17 +15,17 @@ public interface DataRepository extends JpaRepository<Data, Long> {
 
     @Query("select data from Data data "
             + "where data.seller = :member and data.isDeleted = false"
-            + " order by data.createdAt")
+            + " order by data.createdAt desc")
     List<Data> findBySeller(Member member);
 
     @Query("select data from Data data "
         + "join PurchaseHistory purchase_history on data = purchase_history.data "
         + "where purchase_history.buyer = :member"
-        + " order by data.createdAt")
+        + " order by data.createdAt desc")
     List<Data> findByBuyer(Member member);
 
     @Query("select data from Data data "
             + "where data.isDeleted = false"
-            + " order by data.createdAt limit 15 ")
+            + " order by data.createdAt desc limit 15 ")
     List<Data> findRecentData();
 }

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
@@ -2,6 +2,8 @@ package uk.jinhy.survey_mate_api.data.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import uk.jinhy.survey_mate_api.auth.domain.entity.Member;
@@ -12,12 +14,14 @@ public interface DataRepository extends JpaRepository<Data, Long> {
     Optional<Data> findByDataId(Long id);
 
     @Query("select data from Data data "
-            + "where data.seller = :member and data.isDeleted = false")
+            + "where data.seller = :member and data.isDeleted = false"
+            + " order by data.createdAt")
     List<Data> findBySeller(Member member);
 
     @Query("select data from Data data "
         + "join PurchaseHistory purchase_history on data = purchase_history.data "
-        + "where purchase_history.buyer = :member")
+        + "where purchase_history.buyer = :member"
+        + " order by data.createdAt")
     List<Data> findByBuyer(Member member);
 
     @Query("select data from Data data "

--- a/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/presentation/DataController.java
@@ -90,7 +90,7 @@ public class DataController {
     @GetMapping(value = "/list")
     @Operation(summary = "전체 설문장터 조회")
     public ApiResponse<DataControllerDTO.DataListDTO> getDataList() {
-        List<Data> dataList = dataService.getRecentDataList();
+        List<Data> dataList = dataService.getDataList();
         DataControllerDTO.DataListDTO responseDTO = converter.toControllerDataListDto(dataList);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
     }
@@ -109,6 +109,14 @@ public class DataController {
     public ApiResponse<DataControllerDTO.DataListDTO> getDataListAsSeller() {
         Member member = authService.getCurrentMember();
         List<Data> dataList = dataService.getDataListAsSeller(member);
+        DataControllerDTO.DataListDTO responseDTO = converter.toControllerDataListDto(dataList);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
+    }
+
+    @GetMapping(value = "/new")
+    @Operation(summary = "신규 설문장터 조회")
+    public ApiResponse<DataControllerDTO.DataListDTO> getNewDataList() {
+        List<Data> dataList = dataService.getRecentDataList();
         DataControllerDTO.DataListDTO responseDTO = converter.toControllerDataListDto(dataList);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), responseDTO);
     }

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/application/service/StatementService.java
@@ -47,7 +47,7 @@ public class StatementService {
     }
 
     public List<Statement> getStatementList(Member member) {
-        return statementRepository.findByMember(member);
+        return statementRepository.findByMemberOrderByCreatedAtDesc(member);
     }
 
     public Long getTotalAmount(Member member) {

--- a/src/main/java/uk/jinhy/survey_mate_api/statement/domain/repository/StatementRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/statement/domain/repository/StatementRepository.java
@@ -11,17 +11,20 @@ public interface StatementRepository extends JpaRepository<Statement, Long> {
 
     Optional<Statement> findByStatementId(Long id);
 
-    List<Statement> findByMember(Member member);
 
     @Query("select ifnull(sum(statement.amount), 0) from Statement statement "
         + "where statement.member = :member")
     Long findTotalAmountByMember(Member member);
 
+    List<Statement> findByMemberOrderByCreatedAtDesc(Member member);
+
     @Query("select statement from Statement statement "
-        + "where statement.member = :buyer and statement.amount  < 0")
+        + "where statement.member = :buyer and statement.amount  < 0"
+        + " order by statement.createdAt desc")
     List<Statement> findByBuyer(Member buyer);
 
     @Query("select statement from Statement statement "
-        + "where statement.member = :seller and statement.amount  > 0")
+        + "where statement.member = :seller and statement.amount  > 0"
+        + " order by statement.createdAt desc")
     List<Statement> findBySeller(Member seller);
 }


### PR DESCRIPTION
다음과 같은 기능을 구현했습니다
- Data 및 Statement 목록을 조회하는 쿼리를 모두 최신순으로 불러오도록 수정했습니다.
<img width="1108" alt="스크린샷 2024-02-15 오후 5 03 24" src="https://github.com/survey-mate/backend/assets/73176655/b421b78c-1f7a-4f5e-8f1b-c613ec1454ff">
<img width="1053" alt="스크린샷 2024-02-15 오후 5 03 58" src="https://github.com/survey-mate/backend/assets/73176655/86ae1dae-7138-4f05-b885-ddd5fa2efefa">
<img width="1075" alt="스크린샷 2024-02-15 오후 5 04 19" src="https://github.com/survey-mate/backend/assets/73176655/1d159415-aa89-4ce8-befc-e7bf2aaf6279">

- 최신 Data 목록을 불러오는 API를 분리했습니다.
<img width="1107" alt="스크린샷 2024-02-15 오후 5 03 00" src="https://github.com/survey-mate/backend/assets/73176655/b744e661-a64c-41f5-8df9-11bf1dd2a5e8">
