### PR TITLE
fix: 설문장터 삭제된 데이터 조회 수정 #161

### DIFF
--- a/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/application/service/DataService.java
@@ -115,7 +115,7 @@ public class DataService {
                 .orElseThrow(() -> new GeneralException(Status.DATA_NOT_FOUND));
     }
 
-    public List<Data> getDataList() { return dataRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")); }
+    public List<Data> getDataList() { return dataRepository.findAll(); }
 
     public List<Data> getDataListAsBuyer(Member buyer) {
         return dataRepository.findByBuyer(buyer);

--- a/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
+++ b/src/main/java/uk/jinhy/survey_mate_api/data/domain/repository/DataRepository.java
@@ -14,6 +14,11 @@ public interface DataRepository extends JpaRepository<Data, Long> {
     Optional<Data> findByDataId(Long id);
 
     @Query("select data from Data data "
+            + "where data.isDeleted = false"
+            + " order by data.createdAt desc")
+    List<Data> findAll();
+
+    @Query("select data from Data data "
             + "where data.seller = :member and data.isDeleted = false"
             + " order by data.createdAt desc")
     List<Data> findBySeller(Member member);


### PR DESCRIPTION
다음과 같은 기능을 구현했습니다.
- 삭제된 설문장터가 조회되는 에러를 수정했습니다.
삭제전
<img width="1167" alt="스크린샷 2024-02-18 오전 10 01 25" src="https://github.com/survey-mate/backend/assets/73176655/44eaaf75-b754-4468-8e80-8a74cb7f7f3f">

삭제후
<img width="1204" alt="스크린샷 2024-02-18 오전 10 02 13" src="https://github.com/survey-mate/backend/assets/73176655/05cc4f78-8231-4cd1-85ae-4413aeb12eae">
<img width="1222" alt="스크린샷 2024-02-18 오전 10 02 30" src="https://github.com/survey-mate/backend/assets/73176655/ac3f1c18-3098-419f-9efb-c093d8770c70">
<img width="1243" alt="스크린샷 2024-02-18 오전 10 03 18" src="https://github.com/survey-mate/backend/assets/73176655/5d315544-acbb-4b64-a0b4-a92084ebf5ee">
